### PR TITLE
feat: create k8s_service_info library

### DIFF
--- a/lib/charms/harness_extensions/v0/capture_events.py
+++ b/lib/charms/harness_extensions/v0/capture_events.py
@@ -1,0 +1,86 @@
+'''This is a library providing a utility for unittesting events fired on a
+Harness-ed Charm.
+
+Example usage:
+
+>>> from charms.harness_extensions.v0.capture_events import capture
+>>> with capture(RelationEvent) as captured:
+>>>     harness.add_relation('foo', 'remote')
+>>> assert captured.event.unit.name == 'remote'
+'''
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9fcdab70e26d4eee9797c0e542ab397a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from contextlib import contextmanager
+from typing import Generic, Iterator, Optional, Type, TypeVar
+
+from ops.charm import CharmBase
+from ops.framework import EventBase
+
+_T = TypeVar("_T", bound=EventBase)
+
+
+@contextmanager
+def capture_events(charm: CharmBase, *types: Type[EventBase]):
+    """Capture all events of type `*types` (using instance checks)."""
+    allowed_types = types or (EventBase,)
+
+    captured = []
+    _real_emit = charm.framework._emit
+
+    def _wrapped_emit(evt):
+        if isinstance(evt, allowed_types):
+            captured.append(evt)
+        return _real_emit(evt)
+
+    charm.framework._emit = _wrapped_emit  # type: ignore # noqa # ugly
+
+    yield captured
+
+    charm.framework._emit = _real_emit  # type: ignore # noqa # ugly
+
+
+class Captured(Generic[_T]):
+    """Object to type and expose return value of capture()."""
+
+    _event = None
+
+    @property
+    def event(self) -> Optional[_T]:
+        """Return the captured event."""
+        return self._event
+
+    @event.setter
+    def event(self, val: _T):
+        self._event = val
+
+
+@contextmanager
+def capture(charm: CharmBase, typ_: Type[_T] = EventBase) -> Iterator[Captured[_T]]:
+    """Capture exactly 1 event of type `typ_`.
+
+    Will raise if more/less events have been fired, or if the returned event
+    does not pass an instance check.
+    """
+    result = Captured()
+    with capture_events(charm, typ_) as captured:
+        if not captured:
+            yield result
+
+    assert len(captured) <= 1, f"too many events captured: {captured}"
+    assert len(captured) >= 1, f"no event of type {typ_} emitted."
+    event = captured[0]
+    assert isinstance(event, typ_), f"expected {typ_}, not {type(event)}"
+    result.event = event
+

--- a/lib/charms/mlops_libs/v0/k8s_service_info.py
+++ b/lib/charms/mlops_libs/v0/k8s_service_info.py
@@ -173,6 +173,7 @@ class KubernetesServiceInfoRequirer(Object):
         charm (CharmBase): variable for storing the requirer application
         relation_name (str): variable for storing the name of the relation
     """
+
     on = KubernetesServiceInfoEvents()
 
     def __init__(

--- a/lib/charms/mlops_libs/v0/k8s_service_info.py
+++ b/lib/charms/mlops_libs/v0/k8s_service_info.py
@@ -256,9 +256,7 @@ class KubernetesServiceInfoRequirerWrapper(Object):
         # Get relation data from remote app
         relation_data = relation.data[relation.app]
 
-        return KubernetesServiceInfoObject(
-            name=relation_data["name"], port=relation_data["port"]
-        )
+        return KubernetesServiceInfoObject(name=relation_data["name"], port=relation_data["port"])
 
 
 class KubernetesServiceInfoProvider(Object):

--- a/lib/charms/mlops_libs/v0/k8s_service_info.py
+++ b/lib/charms/mlops_libs/v0/k8s_service_info.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for sharing Kubernetes Services information.
+
+This library offers a Python API for providing and requesting information about
+any Kubernetes Service resource.
+The default relation name is `k8s-svc-info` and it's recommended to use that name,
+though if changed, you must ensure to pass the correct name when instantiating the
+provider and requirer classes, as well as in `metadata.yaml`.
+
+## Getting Started
+
+### Fetching the library with charmcraft
+
+Using charmcraft you can:
+```shell
+charmcraft fetch-lib charms.<pending>.v0.k8s_service_info
+```
+
+## Using the library as requirer
+
+### Add relation to metadata.yaml
+```yaml
+requires:
+  k8s-svc-info:
+    interface: k8s-service
+    limit: 1
+```
+
+### Instantiate the KubernetesServiceInfoRequirer class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.<pending>.v0.kubernetes_service_info import KubernetesServiceInfoRequirer, KubernetesServiceInfoRelationError
+
+class RequirerCharm(CharmBase):
+    def __init__(self, *args):
+        self._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+
+    def some_event_function():
+        # use the getter function wherever the info is needed
+        try:
+            k8s_svc_info_data = self._k8s_svc_info_requirer.get_k8s_svc_info()
+        except KubernetesServiceInfoRelationError as error:
+            "your error handler goes here"
+```
+
+## Using the library as provider
+
+### Add relation to metadata.yaml
+```yaml
+provides:
+  k8s-svc-info:
+    interface: k8s-service
+```
+
+### Instantiate the KubernetesServiceInfoProvider class in charm.py
+
+```python
+from ops.charm import CharmBase
+from charms.<pending>.v0.kubernetes_service_info import KubernetesServiceInfoProvider, KubernetesServiceInfoRelationError
+
+class ProviderCharm(CharmBase):
+    def __init__(self, *args, **kwargs):
+        ...
+        self._k8s_svc_info_provider = KubernetesServiceInfoProvider,(self)
+        self.observe(self.on.some_event, self._some_event_handler)
+    def _some_event_handler(self, ...):
+        # This will update the relation data bag with the GRPC Service name and port
+        try:
+            self._k8s_svc_info_provider.send_k8s_svc_info(svc_name, svc_port)
+        except KubernetesServiceInfoRelationError as error:
+            "your error handler goes here"
+```
+
+## Relation data
+
+The data shared by this library is:
+* svc_name: the name of the Kubernetes Service
+  as it appears in the resource metadata, e.g. "metadata-grpc-service".
+* svc_port: the port of the Kubernetes Service
+"""
+
+import logging
+
+from ops.framework import Object
+from ops.model import Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "f5c3f6cc023e40468d6f9a871e8afcd0"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+# Default relation and interface names. If changed, consistency must be kept
+# across the provider and requirer.
+DEFAULT_RELATION_NAME = "k8s-svc-info"
+DEFAULT_INTERFACE_NAME = "k8s-service"
+REQUIRED_ATTRIBUTES = ["svc_name", "svc_port"]
+
+logger = logging.getLogger(__name__)
+
+
+class KubernetesServiceInfoRelationError(Exception):
+    """Base exception class for any relation error handled by this library."""
+
+    pass
+
+
+class KubernetesServiceInfoRelationMissingError(KubernetesServiceInfoRelationError):
+    """Exception to raise when the relation is missing on either end."""
+
+    def __init__(self):
+        self.message = "Missing k8s-svc-info relation."
+        super().__init__(self.message)
+
+
+class KubernetesServiceInfoRelationDataMissingError(KubernetesServiceInfoRelationError):
+    """Exception to raise when there is missing data in the relation data bag."""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class KubernetesServiceInfoRequirer(Object):
+    """Base class that represents a requirer relation end.
+
+    Args:
+        requirer_charm (CharmBase): the requirer application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, requirer_charm, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(requirer_charm, relation_name)
+        self.relation_name = relation_name
+
+    @staticmethod
+    def _relation_preflight_checks(relation: Relation) -> None:
+        """Series of checks for the relation and relation data.
+
+        Args:
+            relation (Relation): the relation object to run the checks on
+
+        Raises:
+            KubernetesServiceInfoRelationDataMissingError if data is missing or incomplete
+            KubernetesServiceInfoRelationMissingError: if there is no related application
+            ops.model.TooManyRelatedAppsError: if there is more than one related application
+        """
+        # Raise if there is no related application
+        if not relation:
+            raise KubernetesServiceInfoRelationMissingError()
+
+        # Extract remote app information from relation
+        remote_app = relation.app
+        # Get relation data from remote app
+        relation_data = relation.data[remote_app]
+
+        # Raise if there is no data found in the relation data bag
+        if not relation_data:
+            raise KubernetesServiceInfoRelationDataMissingError(
+                "No data found in relation data bag."
+            )
+
+        # Check if the relation data contains the expected attributes
+        missing_attributes = [
+            attribute for attribute in REQUIRED_ATTRIBUTES if attribute not in relation_data
+        ]
+        if missing_attributes:
+            raise KubernetesServiceInfoRelationDataMissingError(
+                f"Missing attributes: {missing_attributes}"
+            )
+
+    def get_k8s_svc_info(self) -> dict:
+        """Return a dictionary with the Kubernetes Service information.
+
+        Raises:
+            KubernetesServiceInfoRelationDataMissingError: if data is missing entirely or some attributes
+            KubernetesServiceInfoRelationMissingError: if there is no related application
+        """
+        # Run pre-flight checks
+        # Raises TooManyRelatedAppsError if related to more than one app
+        relation = self.model.get_relation(self.relation_name)
+        self._relation_preflight_checks(relation=relation)
+
+        # Get relation data from remote app
+        relation_data = relation.data[relation.app]
+
+        return {
+            "svc_name": relation_data["svc_name"],
+            "svc_port": relation_data["svc_port"],
+        }
+
+
+class KubernetesServiceInfoProvider(Object):
+    """Base class that represents a provider relation end.
+
+    Args:
+        provider_charm (CharmBase): the provider application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        provider_charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, provider_charm, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(provider_charm, relation_name)
+        self.provider_charm = provider_charm
+        self.relation_name = relation_name
+
+    def send_k8s_svc_info_relation_data(
+        self,
+        svc_name: str,
+        svc_port: str,
+    ) -> None:
+        """Update the relation data bag with data from a Kubernetes Service.
+
+        This method will complete successfully even if there are no related applications.
+
+        Args:
+            svc_name (str): the name of the Kubernetes Service the provider knows about
+            svc_port (str): the port number of the Kubernetes Service the provider knows about
+        """
+        # Update the relation data bag with a Kubernetes Service information
+        relations = self.model.relations[self.relation_name]
+
+        # Update relation data
+        for relation in relations:
+            relation.data[self.provider_charm.app].update(
+                {
+                    "svc_name": svc_name,
+                    "svc_port": svc_port,
+                }
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-ops ~= 2.5
+ops
+pydantic

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -4,6 +4,8 @@
 
 import pytest
 from charms.mlops_libs.v0.k8s_service_info import (
+    KubernetesServiceInfoObject,
+    KubernetesServiceInfoProvider,
     KubernetesServiceInfoProviderWrapper,
     KubernetesServiceInfoRelationDataMissingError,
     KubernetesServiceInfoRelationMissingError,
@@ -13,8 +15,6 @@ from ops.charm import CharmBase
 from ops.model import TooManyRelatedAppsError
 from ops.testing import Harness
 
-DEFAULT_RELATION_NAME = "k8s-svc-info"
-DEFAULT_INTERFACE_NAME = "k8s-service"
 TEST_RELATION_NAME = "test-relation"
 REQUIRER_CHARM_META = f"""
 name: requirer-test-charm
@@ -44,29 +44,31 @@ def provider_charm_harness():
     return Harness(GenericCharm, meta=PROVIDER_CHARM_META)
 
 
-def test_get_k8s_svc_info_passes(requirer_charm_harness):
+def test_get_data_passes(requirer_charm_harness):
     """Assert the relation data is as expected."""
     # Initial configuration
     requirer_charm_harness.set_model_name("test-model")
-    requirer_charm_harness.begin()
     requirer_charm_harness.set_leader(True)
-    relation_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+    requirer_charm_harness.begin()
+
+    # Add and update relation
+    data_dict = {"svc_name": "some-service", "svc_port": "7878"}
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
 
     # Instantiate KubernetesServiceInfoRequirer class
     requirer_charm_harness.charm._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(
         requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
     )
 
-    # Add and update relation
-    relation_data = {"svc_name": "some-service", "svc_port": "7878"}
-    requirer_charm_harness.add_relation_unit(relation_id, "app/0")
-    requirer_charm_harness.update_relation_data(relation_id, "app", relation_data)
-
     # Get the relation data
-    actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+    expected_data = KubernetesServiceInfoObject(
+        name=data_dict["svc_name"], port=data_dict["svc_port"]
+    )
+    actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
 
     # Assert returns dictionary with expected values
-    assert actual_relation_data == relation_data
+    assert actual_relation_data.name == expected_data.name
+    assert actual_relation_data.port == expected_data.port
 
 
 def test_check_raise_too_many_relations(requirer_charm_harness):
@@ -84,10 +86,10 @@ def test_check_raise_too_many_relations(requirer_charm_harness):
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app2")
 
     with pytest.raises(TooManyRelatedAppsError):
-        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
 
 
-def test_preflight_checks_raise_no_relation(requirer_charm_harness):
+def test_validate_relation_raise_no_relation(requirer_charm_harness):
     """Assert that  KubernetesServiceInfoRelationMissingError is raised in the absence of the relation."""
     requirer_charm_harness.set_model_name("test-model")
     requirer_charm_harness.begin()
@@ -99,10 +101,10 @@ def test_preflight_checks_raise_no_relation(requirer_charm_harness):
     )
 
     with pytest.raises(KubernetesServiceInfoRelationMissingError):
-        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
 
 
-def test_preflight_checks_raise_no_relation_data(requirer_charm_harness):
+def test_validate_relation_raise_no_relation_data(requirer_charm_harness):
     """Assert that KubernetesServiceInfoRelationDataMissingError is raised in the absence of relation data."""
     requirer_charm_harness.set_model_name("test-model")
     requirer_charm_harness.begin()
@@ -116,17 +118,16 @@ def test_preflight_checks_raise_no_relation_data(requirer_charm_harness):
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
     with pytest.raises(KubernetesServiceInfoRelationDataMissingError) as error:
-        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
     assert str(error.value) == f"No data found in relation {TEST_RELATION_NAME} data bag."
 
 
-def test_preflight_checks_raises_data_missing_attribute(requirer_charm_harness):
+def test_validate_relation_raises_data_missing_attribute(requirer_charm_harness):
     """Assert KubernetesServiceInfoRelationDataMissingError is raised in the absence of a relation data attribute."""
     # Initial configuration
     requirer_charm_harness.set_model_name("test-model")
     requirer_charm_harness.begin()
     requirer_charm_harness.set_leader(True)
-    relation_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
     # Instantiate KubernetesServiceInfoRequirer class
     requirer_charm_harness.charm._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(
@@ -135,38 +136,63 @@ def test_preflight_checks_raises_data_missing_attribute(requirer_charm_harness):
 
     # Add and update relation
     faulty_relation_data = {"svc_name": "name"}
-    requirer_charm_harness.add_relation_unit(relation_id, "app/0")
-    requirer_charm_harness.update_relation_data(relation_id, "app", faulty_relation_data)
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=faulty_relation_data)
 
     with pytest.raises(KubernetesServiceInfoRelationDataMissingError) as error:
-        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
     assert str(error.value) == f"Missing attributes: ['svc_port'] in relation {TEST_RELATION_NAME}"
 
 
-def test_send_relation_data_passes(provider_charm_harness):
-    """Assert the relation data is as expected."""
+def test_provider_sends_data_automatically_passes(provider_charm_harness):
+    """Assert the relation data is passed automatically by the provider."""
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.set_leader(True)
+    provider_charm_harness.begin()
+
+    # Instantiate the KubernetesServiceInfoProvider
+    svc_name = "some-svc"
+    svc_port = "7878"
+    provider_charm_harness.charm._k8s_svc_info_provider = KubernetesServiceInfoProvider(
+        charm=provider_charm_harness.charm,
+        svc_name=svc_name,
+        svc_port=svc_port,
+        relation_name=TEST_RELATION_NAME,
+    )
+
+    # Add corresponding relation
+    provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Check the relation data
+    relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
+    for relation in relations:
+        actual_relation_data = relation.data[provider_charm_harness.charm.app]
+        # Assert returns dictionary with expected values
+        assert actual_relation_data.get("svc_name") == svc_name
+        assert actual_relation_data.get("svc_port") == svc_port
+
+
+def test_provider_wrapper_send_data_passes(provider_charm_harness):
+    """Assert the relation data is as expected by the provider wrapper."""
     # Initial configuration
     provider_charm_harness.set_model_name("test-model")
     provider_charm_harness.begin()
     provider_charm_harness.set_leader(True)
-    relation_id = provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
     provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
-    # Instantiate KubernetesServiceInfoRequirer class
+    # Instantiate KubernetesServiceInfoProviderWrapper class
     provider_charm_harness.charm._k8s_svc_info_provider = KubernetesServiceInfoProviderWrapper(
         provider_charm_harness.charm,
         relation_name=TEST_RELATION_NAME,
     )
 
-    # Add and update relation
-    provider_charm_harness.add_relation_unit(relation_id, "app/0")
-
-    relation_data = {"svc_name": "some-service", "svc_port": "7878"}
-    provider_charm_harness.charm._k8s_svc_info_provider.send_k8s_svc_info_relation_data(
-        svc_name=relation_data["svc_name"], svc_port=relation_data["svc_port"]
+    # Send relation data
+    relation_data = KubernetesServiceInfoObject(name="some-service", port="7878")
+    provider_charm_harness.charm._k8s_svc_info_provider.send_data(
+        svc_name=relation_data.name, svc_port=relation_data.port
     )
     relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
     for relation in relations:
         actual_relation_data = relation.data[provider_charm_harness.charm.app]
         # Assert returns dictionary with expected values
-        assert actual_relation_data == relation_data
+        assert actual_relation_data.get("svc_name") == relation_data.name
+        assert actual_relation_data.get("svc_port") == relation_data.port

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -45,7 +45,7 @@ def provider_charm_harness():
     return Harness(GenericCharm, meta=PROVIDER_CHARM_META)
 
 
-def test_requirer_data_in_relation_passes(requirer_charm_harness):
+def test_requirer_get_data_automatically_passes(requirer_charm_harness):
     """Assert the relation data is as expected."""
     # Initial configuration
     requirer_charm_harness.set_model_name("test-model")
@@ -134,12 +134,12 @@ def test_validate_relation_raises_data_missing_attribute(requirer_charm_harness)
     )
 
     # Add and update relation
-    faulty_relation_data = {"svc_name": "name"}
+    faulty_relation_data = {"name": "name"}
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=faulty_relation_data)
 
     with pytest.raises(KubernetesServiceInfoRelationDataMissingError) as error:
         requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
-    assert str(error.value) == f"Missing attributes: ['svc_port'] in relation {TEST_RELATION_NAME}"
+    assert str(error.value) == f"Missing attributes: ['port'] in relation {TEST_RELATION_NAME}"
 
 
 def test_provider_sends_data_automatically_passes(provider_charm_harness):
@@ -153,8 +153,8 @@ def test_provider_sends_data_automatically_passes(provider_charm_harness):
     svc_port = "7878"
     provider_charm_harness.charm._k8s_svc_info_provider = KubernetesServiceInfoProvider(
         charm=provider_charm_harness.charm,
-        svc_name=svc_name,
-        svc_port=svc_port,
+        name=svc_name,
+        port=svc_port,
         relation_name=TEST_RELATION_NAME,
     )
 
@@ -166,8 +166,8 @@ def test_provider_sends_data_automatically_passes(provider_charm_harness):
     for relation in relations:
         actual_relation_data = relation.data[provider_charm_harness.charm.app]
         # Assert returns dictionary with expected values
-        assert actual_relation_data.get("svc_name") == svc_name
-        assert actual_relation_data.get("svc_port") == svc_port
+        assert actual_relation_data.get("name") == svc_name
+        assert actual_relation_data.get("port") == svc_port
 
 
 def test_requirer_wrapper_get_data_passes(requirer_charm_harness):
@@ -178,7 +178,7 @@ def test_requirer_wrapper_get_data_passes(requirer_charm_harness):
     requirer_charm_harness.begin()
 
     # Add and update relation
-    data_dict = {"svc_name": "some-service", "svc_port": "7878"}
+    data_dict = {"name": "some-service", "port": "7878"}
     requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
 
     # Instantiate KubernetesServiceInfoRequirerWrapper class
@@ -188,7 +188,7 @@ def test_requirer_wrapper_get_data_passes(requirer_charm_harness):
 
     # Get the relation data
     expected_data = KubernetesServiceInfoObject(
-        name=data_dict["svc_name"], port=data_dict["svc_port"]
+        name=data_dict["name"], port=data_dict["port"]
     )
     actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
 
@@ -213,11 +213,11 @@ def test_provider_wrapper_send_data_passes(provider_charm_harness):
     # Send relation data
     relation_data = KubernetesServiceInfoObject(name="some-service", port="7878")
     provider_charm_harness.charm._k8s_svc_info_provider.send_data(
-        svc_name=relation_data.name, svc_port=relation_data.port
+        name=relation_data.name, port=relation_data.port
     )
     relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
     for relation in relations:
         actual_relation_data = relation.data[provider_charm_harness.charm.app]
         # Assert returns dictionary with expected values
-        assert actual_relation_data.get("svc_name") == relation_data.name
-        assert actual_relation_data.get("svc_port") == relation_data.port
+        assert actual_relation_data.get("name") == relation_data.name
+        assert actual_relation_data.get("port") == relation_data.port

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -187,9 +187,7 @@ def test_requirer_wrapper_get_data_passes(requirer_charm_harness):
     )
 
     # Get the relation data
-    expected_data = KubernetesServiceInfoObject(
-        name=data_dict["name"], port=data_dict["port"]
-    )
+    expected_data = KubernetesServiceInfoObject(name=data_dict["name"], port=data_dict["port"])
     actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
 
     # Assert returns dictionary with expected values

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from charms.mlops_libs.v0.k8s_service_info import (
+    KubernetesServiceInfoProvider,
+    KubernetesServiceInfoRelationDataMissingError,
+    KubernetesServiceInfoRelationMissingError,
+    KubernetesServiceInfoRequirer,
+)
+from ops.charm import CharmBase
+from ops.model import TooManyRelatedAppsError
+from ops.testing import Harness
+
+DEFAULT_RELATION_NAME = "k8s-svc-info"
+DEFAULT_INTERFACE_NAME = "k8s-service"
+TEST_RELATION_NAME = "test-relation"
+REQUIRER_CHARM_META = f"""
+name: requirer-test-charm
+requires:
+  {TEST_RELATION_NAME}:
+    interface: test-interface
+"""
+PROVIDER_CHARM_META = f"""
+name: provider-test-charm
+provides:
+  {TEST_RELATION_NAME}:
+    interface: test-interface
+"""
+
+
+class GenericCharm(CharmBase):
+    pass
+
+
+@pytest.fixture()
+def requirer_charm_harness():
+    return Harness(GenericCharm, meta=REQUIRER_CHARM_META)
+
+
+@pytest.fixture()
+def provider_charm_harness():
+    return Harness(GenericCharm, meta=PROVIDER_CHARM_META)
+
+
+def test_get_k8s_svc_info_passes(requirer_charm_harness):
+    """Assert the relation data is as expected."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+    relation_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Instantiate KubernetesServiceInfoRequirer class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Add and update relation
+    relation_data = {"svc_name": "some-service", "svc_port": "7878"}
+    requirer_charm_harness.add_relation_unit(relation_id, "app/0")
+    requirer_charm_harness.update_relation_data(relation_id, "app", relation_data)
+
+    # Get the relation data
+    actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+
+    # Assert returns dictionary with expected values
+    assert actual_relation_data == relation_data
+
+
+def test_check_raise_too_many_relations(requirer_charm_harness):
+    """Assert that TooManyRelatedAppsError is raised if more than one application is related."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate KubernetesServiceInfoRequirer class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app2")
+
+    with pytest.raises(TooManyRelatedAppsError):
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+
+
+def test_preflight_checks_raise_no_relation(requirer_charm_harness):
+    """Assert that  KubernetesServiceInfoRelationMissingError is raised in the absence of the relation."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate KubernetesServiceInfoRequirer class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    with pytest.raises(KubernetesServiceInfoRelationMissingError):
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+
+
+def test_preflight_checks_raise_no_relation_data(requirer_charm_harness):
+    """Assert that KubernetesServiceInfoRelationDataMissingError is raised in the absence of relation data."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate KubernetesServiceInfoRequirer class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    with pytest.raises(KubernetesServiceInfoRelationDataMissingError) as error:
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+    assert str(error.value) == "No data found in relation data bag."
+
+
+def test_preflight_checks_raises_data_missing_attribute(requirer_charm_harness):
+    """Assert KubernetesServiceInfoRelationDataMissingError is raised in the absence of a relation data attribute."""
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+    relation_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Instantiate KubernetesServiceInfoRequirer class
+    requirer_charm_harness.charm._k8s_svc_info_requirer = KubernetesServiceInfoRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Add and update relation
+    faulty_relation_data = {"svc_name": "name"}
+    requirer_charm_harness.add_relation_unit(relation_id, "app/0")
+    requirer_charm_harness.update_relation_data(relation_id, "app", faulty_relation_data)
+
+    with pytest.raises(KubernetesServiceInfoRelationDataMissingError) as error:
+        requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
+    assert str(error.value) == "Missing attributes: ['svc_port']"
+
+
+def test_send_relation_data_passes(provider_charm_harness):
+    """Assert the relation data is as expected."""
+    # Initial configuration
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.begin()
+    provider_charm_harness.set_leader(True)
+    relation_id = provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+    provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Instantiate KubernetesServiceInfoRequirer class
+    provider_charm_harness.charm._k8s_svc_info_provider = KubernetesServiceInfoProvider(
+        provider_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Add and update relation
+    provider_charm_harness.add_relation_unit(relation_id, "app/0")
+
+    relation_data = {"svc_name": "some-service", "svc_port": "7878"}
+    provider_charm_harness.charm._k8s_svc_info_provider.send_k8s_svc_info_relation_data(
+        **relation_data
+    )
+    relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
+    for relation in relations:
+        actual_relation_data = relation.data[provider_charm_harness.charm.app]
+        # Assert returns dictionary with expected values
+        assert actual_relation_data == relation_data

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -12,6 +12,7 @@ from charms.mlops_libs.v0.k8s_service_info import (
     KubernetesServiceInfoRequirer,
     KubernetesServiceInfoRequirerWrapper,
 )
+from charms.harness_extensions.v0.capture_events import capture
 from ops.charm import CharmBase
 from ops.model import TooManyRelatedAppsError
 from ops.testing import Harness
@@ -90,7 +91,10 @@ def test_get_k8s_svc_info_on_refresh_event(requirer_charm_harness):
     relation = requirer_charm_harness.charm.framework.model.get_relation(
         TEST_RELATION_NAME, rel_id
     )
-    requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined.emit(relation)
+
+    # Assert that we emit an event for data being updated
+    with capture(harness.charm, KubernetesServiceInfoUpdatedEvent):
+        requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined.emit(relation)
 
 
 def test_check_raise_too_many_relations(requirer_charm_harness):

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -4,7 +4,7 @@
 
 import pytest
 from charms.mlops_libs.v0.k8s_service_info import (
-    KubernetesServiceInfoProvider,
+    KubernetesServiceInfoProviderWrapper,
     KubernetesServiceInfoRelationDataMissingError,
     KubernetesServiceInfoRelationMissingError,
     KubernetesServiceInfoRequirer,
@@ -117,7 +117,7 @@ def test_preflight_checks_raise_no_relation_data(requirer_charm_harness):
 
     with pytest.raises(KubernetesServiceInfoRelationDataMissingError) as error:
         requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
-    assert str(error.value) == "No data found in relation data bag."
+    assert str(error.value) == f"No data found in relation {TEST_RELATION_NAME} data bag."
 
 
 def test_preflight_checks_raises_data_missing_attribute(requirer_charm_harness):
@@ -140,7 +140,7 @@ def test_preflight_checks_raises_data_missing_attribute(requirer_charm_harness):
 
     with pytest.raises(KubernetesServiceInfoRelationDataMissingError) as error:
         requirer_charm_harness.charm._k8s_svc_info_requirer.get_k8s_svc_info()
-    assert str(error.value) == "Missing attributes: ['svc_port']"
+    assert str(error.value) == f"Missing attributes: ['svc_port'] in relation {TEST_RELATION_NAME}"
 
 
 def test_send_relation_data_passes(provider_charm_harness):
@@ -153,8 +153,9 @@ def test_send_relation_data_passes(provider_charm_harness):
     provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
     # Instantiate KubernetesServiceInfoRequirer class
-    provider_charm_harness.charm._k8s_svc_info_provider = KubernetesServiceInfoProvider(
-        provider_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    provider_charm_harness.charm._k8s_svc_info_provider = KubernetesServiceInfoProviderWrapper(
+        provider_charm_harness.charm,
+        relation_name=TEST_RELATION_NAME,
     )
 
     # Add and update relation
@@ -162,7 +163,7 @@ def test_send_relation_data_passes(provider_charm_harness):
 
     relation_data = {"svc_name": "some-service", "svc_port": "7878"}
     provider_charm_harness.charm._k8s_svc_info_provider.send_k8s_svc_info_relation_data(
-        **relation_data
+        svc_name=relation_data["svc_name"], svc_port=relation_data["svc_port"]
     )
     relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
     for relation in relations:

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -14,7 +14,6 @@ from charms.mlops_libs.v0.k8s_service_info import (
     KubernetesServiceInfoRequirerWrapper,
     KubernetesServiceInfoUpdatedEvent,
 )
-from charms.harness_extensions.v0.capture_events import capture
 from ops.charm import CharmBase
 from ops.model import TooManyRelatedAppsError
 from ops.testing import Harness

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -60,7 +60,7 @@ def test_requirer_get_data_from_requirer(requirer_charm_harness):
     # Add and update relation
     expected_data = KubernetesServiceInfoObject(name="some-service", port="7878")
     data_dict = {"name": expected_data.name, "port": expected_data.port}
-    rel_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
 
     # Get the relation data
     actual_relation_data = requirer_charm_harness.charm._k8s_svc_info_requirer.get_data()
@@ -87,9 +87,11 @@ def test_get_k8s_svc_info_on_refresh_event(requirer_charm_harness):
     expected_data = KubernetesServiceInfoObject(name="some-service", port="7878")
     data_dict = {"name": expected_data.name, "port": expected_data.port}
     rel_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app", app_data=data_dict)
-    relation = requirer_charm_harness.charm.framework.model.get_relation(TEST_RELATION_NAME, rel_id)
+    relation = requirer_charm_harness.charm.framework.model.get_relation(
+        TEST_RELATION_NAME, rel_id
+    )
     requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined.emit(relation)
-   
+
 
 def test_check_raise_too_many_relations(requirer_charm_harness):
     """Assert that TooManyRelatedAppsError is raised if more than one application is related."""

--- a/tests/unit/test_k8s_service_info.py
+++ b/tests/unit/test_k8s_service_info.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 import pytest
+from charms.harness_extensions.v0.capture_events import capture
 from charms.mlops_libs.v0.k8s_service_info import (
     KubernetesServiceInfoObject,
     KubernetesServiceInfoProvider,
@@ -11,6 +12,7 @@ from charms.mlops_libs.v0.k8s_service_info import (
     KubernetesServiceInfoRelationMissingError,
     KubernetesServiceInfoRequirer,
     KubernetesServiceInfoRequirerWrapper,
+    KubernetesServiceInfoUpdatedEvent,
 )
 from charms.harness_extensions.v0.capture_events import capture
 from ops.charm import CharmBase
@@ -93,7 +95,7 @@ def test_get_k8s_svc_info_on_refresh_event(requirer_charm_harness):
     )
 
     # Assert that we emit an event for data being updated
-    with capture(harness.charm, KubernetesServiceInfoUpdatedEvent):
+    with capture(requirer_charm_harness, KubernetesServiceInfoUpdatedEvent):
         requirer_charm_harness.charm.on[TEST_RELATION_NAME].relation_joined.emit(relation)
 
 


### PR DESCRIPTION
This library provides functionality for sharing Kubernetes Service information using the k8s-service relation interface. Please refer to #2 for details.

> NOTE: please merge after #4 

Fixes #2