### PR TITLE
ci: add on pull/push CI workflows

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,0 +1,32 @@
+# reusable workflow triggered by other actions
+name: CI
+
+jobs:
+
+  lint:
+    name: Lint Check
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: sudo apt-get install python3-pip tox
+
+    - name: Lint code
+      run: tox -e lint
+
+  unit:
+    name: Unit Test
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: sudo apt-get install python3-pip tox
+
+    - name: Run unit tests
+      run: tox -e unit

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -14,7 +14,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install dependencies
-      run: sudo apt-get install python3-pip tox
+      run: |
+        sudo apt-get install python3-pip
+        python3 -m pip install tox
 
     - name: Lint code
       run: tox -e lint

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,8 +1,10 @@
 # reusable workflow triggered by other actions
 name: CI
 
-jobs:
+on:
+  workflow_call:
 
+jobs:
   lint:
     name: Lint Check
     runs-on: ubuntu-20.04

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,0 +1,14 @@
+name: On Pull Request
+
+# On pull_request, we:
+# * always publish to charmhub at latest/edge/branchname
+# * always run tests
+
+on:
+  pull_request:
+
+jobs:
+
+  tests:
+    name: Run Tests
+    uses: ./.github/workflows/integrate.yaml

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,0 +1,20 @@
+name: On Push
+
+# On push to a "special" branch, we:
+# * always publish to charmhub at latest/edge/branchname
+# * always run tests
+# where a "special" branch is one of main/master or track/**, as
+# by convention these branches are the source for a corresponding
+# charmhub edge channel.
+
+on:
+  push:
+    branches:
+    - master
+    - main
+    - track/**
+
+jobs:
+  tests:
+    name: Run Tests
+    uses: ./.github/workflows/integrate.yaml

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -10,7 +10,6 @@ name: On Push
 on:
   push:
     branches:
-    - master
     - main
     - track/**
 


### PR DESCRIPTION
This commit adds the corresponding workflows for on pull and push actions, enabling linting and unit testing.

The CI is expected to fail because we are yet to populate the repository with valid code and test files.